### PR TITLE
:foggy: Mapping changes to support search changes

### DIFF
--- a/config/esConfig.js
+++ b/config/esConfig.js
@@ -15,7 +15,7 @@ const esConfig = {
   monitorPrefix: process.env.ES_MONITOR_PREFIX || '.monitoring-es-6-',
   // hold mappings and transforms on settings to allow adding pharmacy config in future
   settings: {
-    profiles: {
+    profiles2: {
       type: 'gps',
       idKey: 'choicesId',
       mapping: profilesMapping,

--- a/config/profiles/mapping.json
+++ b/config/profiles/mapping.json
@@ -11,6 +11,16 @@
           "type":"custom",
           "tokenizer":"name_tokenizer",
           "filter":[ "lowercase", "surgery_name_stop", "trigrams_filter" ]
+        },
+        "shingle_surgery_name_analyzer":{
+          "type":"custom",
+          "tokenizer":"name_tokenizer",
+          "filter":[ "lowercase", "shingle_filter" ]
+        },
+        "reverse_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "reverse"]
         }
       },
       "tokenizer": {
@@ -19,7 +29,7 @@
           "pattern": "[^a-zA-Z']+"
         }
       },
-      "filter":{
+      "filter": {
         "surgery_name_stop":{
           "type":"stop",
           "stopwords": [ "surgery", "health", "centre", "medical" ]
@@ -28,6 +38,11 @@
           "type":     "ngram",
           "min_gram": 3,
           "max_gram": 3
+        },
+        "shingle_filter": {
+          "type": "shingle",
+          "min_shingle_size": 2,
+          "max_shingle_size": 3
         }
       }
     }
@@ -82,6 +97,14 @@
              "trigram": {
                "type": "text",
                "analyzer": "fuzzy_surgery_name_analyzer"
+             },
+             "shingle": {
+               "type": "text",
+               "analyzer": "shingle_surgery_name_analyzer"
+             },
+             "reverse": {
+               "type": "text",
+               "analyzer": "reverse_analyzer"
              }
           }
         },

--- a/config/profiles/mapping.json
+++ b/config/profiles/mapping.json
@@ -2,10 +2,15 @@
   "settings":{
     "analysis":{
       "analyzer":{
-        "gp_name_analyzer":{
+        "surgery_name_analyzer":{
           "type":"custom",
           "tokenizer":"name_tokenizer",
-          "filter":[ "lowercase", "gp_title_stop" ]
+          "filter":[ "lowercase", "surgery_name_stop" ]
+        },
+        "fuzzy_surgery_name_analyzer":{
+          "type":"custom",
+          "tokenizer":"name_tokenizer",
+          "filter":[ "lowercase", "surgery_name_stop", "trigrams_filter" ]
         }
       },
       "tokenizer": {
@@ -15,9 +20,14 @@
         }
       },
       "filter":{
-        "gp_title_stop":{
+        "surgery_name_stop":{
           "type":"stop",
-          "stopwords": [ "doctor", "doctors", "dr", "drs" ]
+          "stopwords": [ "surgery", "health", "centre", "medical" ]
+        },
+        "trigrams_filter": {
+          "type":     "ngram",
+          "min_gram": 3,
+          "max_gram": 3
         }
       }
     }
@@ -50,44 +60,10 @@
           "type": "boolean"
         },
         "address": {
-          "properties": {
-            "addressLines": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-            "postcode": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            }
-          }
+          "enabled": false
         },
         "displayName": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          }
-        },
-        "doctors": {
-          "type": "nested",
-          "properties": {
-            "name" : {
-              "type": "string",
-              "analyzer": "gp_name_analyzer"
-            }
-          }
+          "enabled": false
         },
         "location" : {
           "properties" : {
@@ -99,10 +75,27 @@
         "name": {
           "type": "text",
           "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+             "precise": {
+               "type": "text",
+               "analyzer": "surgery_name_analyzer"
+             },
+             "trigram": {
+               "type": "text",
+               "analyzer": "fuzzy_surgery_name_analyzer"
+             }
+          }
+        },
+        "alternativeName": {
+          "type": "text",
+          "fields": {
+             "precise": {
+               "type": "text",
+               "analyzer": "surgery_name_analyzer"
+             },
+             "trigram": {
+               "type": "text",
+               "analyzer": "fuzzy_surgery_name_analyzer"
+             }
           }
         }
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       UPDATE_SCHEDULE: ${UPDATE_SCHEDULE}
       JSON_FILE_URL: https://nhsukgpdataetl.blob.core.windows.net/etl-output/gp-data-merged.json
       ES_HOST: es
-      ES_INDEX: profiles
+      ES_INDEX: profiles2
       CHANGE_THRESHOLD: '0.96'
 
   elasticsearch-updater-profiles:
@@ -22,7 +22,7 @@ services:
       - elasticsearch-updater-profiles-node_modules:/code/node_modules
     environment:
       JSON_FILE_URL: https://nhsukgpdataetl.blob.core.windows.net/etl-output/gp-data-merged.json
-      ES_INDEX: profiles
+      ES_INDEX: profiles2
     links:
     - elasticsearch:es
 

--- a/scripts/start
+++ b/scripts/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 docker-compose down -v
-docker-compose up --build --force-recreate elasticsearch elasticsearch-updater-profiles elasticsearch-updater-pharmacies
+docker-compose up --build --force-recreate elasticsearch elasticsearch-updater-profiles


### PR DESCRIPTION
* Simplify mapping to reflect return to surgery name only search
* Add support for trigram searching to explore typo handling

Query to show it in action:

`curl -s -XPOST 'localhost:9200/profiles2/_search?pretty' -H 'Content-Type: application/json' -d @ngram-query.json  | jq -C '.hits.hits[]._source | { name, alternativeName, searchSurgery }' | less -R`

Where the file `ngram-query.json` is from [here](https://github.com/neilbmclaughlin/sample-queries/blob/master/ngram-query.json)

This PR is for experimental purposes only - not to be merged.