### PR TITLE
update mapping and transform for sexual health services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-0.9.0 / TBA
+0.10.0 / TBA
+==================
+- Changes to sexual health services mapping and transform to support pharmacy data and aggregation
+
+0.9.0 / 2018-03-28
 ==================
 - Remove snyk, update packages
 - Improve layout of `README`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.10.0 / TBA
+0.10.0 / 2018-04-12
 ==================
 - Changes to sexual health services mapping and transform to support pharmacy data and aggregation
 

--- a/config/sexual-health-services/getSettings.js
+++ b/config/sexual-health-services/getSettings.js
@@ -1,9 +1,11 @@
 const mapping = require('./mapping');
+const transform = require('./transform');
 
 function getSettings() {
   return {
     idKey: 'id',
     mapping,
+    transform,
     type: 'sexual-health-service',
   };
 }

--- a/config/sexual-health-services/mapping.json
+++ b/config/sexual-health-services/mapping.json
@@ -4,6 +4,9 @@
   "mappings": {
     "sexual-health-service": {
       "properties": {
+        "openingTimes": {
+          "enabled": false
+        },
         "location" : {
           "properties" : {
             "coordinates" : {

--- a/config/sexual-health-services/transform.js
+++ b/config/sexual-health-services/transform.js
@@ -1,0 +1,11 @@
+function addUid(record) {
+  // eslint-disable-next-line no-param-reassign
+  record.uid = record.gsdId || record.odsCode || record.id;
+  return record;
+}
+
+function transform(data) {
+  return data && data.map(addUid);
+}
+
+module.exports = transform;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-updater",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Updates an Elasticsearch instance from a JSON file",
   "main": "scheduler.js",
   "repository": "https://github.com/nhsuk/elasticsearch-updater.git",

--- a/test/unit/sexual-health-services/transform.js
+++ b/test/unit/sexual-health-services/transform.js
@@ -1,0 +1,34 @@
+const chai = require('chai');
+
+const transform = require('../../../config/sexual-health-services/transform');
+
+const expect = chai.expect;
+const id = '123';
+
+describe('Sexual Health Services transform', () => {
+  it('should use gsId as uid if available', () => {
+    const gsdId = 'gsd01';
+    const transformedData = transform([
+      { gsdId, id },
+    ]);
+    expect(transformedData.length).to.equal(1);
+    expect(transformedData[0].uid).to.equal(gsdId);
+  });
+
+  it('should use odsCode as uid if gsdId not available', () => {
+    const odsCode = 'ods001';
+    const transformedData = transform([
+      { id, odsCode },
+    ]);
+    expect(transformedData.length).to.equal(1);
+    expect(transformedData[0].uid).to.equal(odsCode);
+  });
+
+  it('should use id as uid if gsdId or odsCode not available', () => {
+    const transformedData = transform([
+      { id },
+    ]);
+    expect(transformedData.length).to.equal(1);
+    expect(transformedData[0].uid).to.equal(id);
+  });
+});


### PR DESCRIPTION
Update mapping to prevent memory issues when ES is parsing opening times.
Add uid field keyed from either gdsId, odsCode, or id to allow aggregation to remove duplicates.